### PR TITLE
Breaking:  `--importExtension`

### DIFF
--- a/lib/Options.ts
+++ b/lib/Options.ts
@@ -5,7 +5,7 @@ interface Options {
   extensions: string[]
   force: boolean
   indexFileExtension: string
-  tsNodeNext: boolean
+  importExtension?: string
 }
 
 export default Options

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -13,11 +13,7 @@ new Command()
   .option('-e, --extensions <>', 'Files with which extensions to export', '.js, .jsx, .ts, .tsx')
   .option('-f, --force', "Overwrite / delete index.js files that aren't ignored by git", false)
   .option('-o, --indexFileExtension <>', 'Extension of file to create', '.js')
-  .option(
-    '-n, --tsNodeNext',
-    'Generates TypeScript files that follow NodeNext module resolution ' +
-    '(https://www.typescriptlang.org/tsconfig#moduleResolution).',
-    false)
+  .option('-i, --importExtension <>', 'Customize the extension for imported files')
   .action((dir, options) => {
     options.extensions = options.extensions.split(',').map(s => s.trim())
     options.dir = dir !== undefined ? normalize(dir) : process.cwd()

--- a/lib/cliRunWithWatch.ts
+++ b/lib/cliRunWithWatch.ts
@@ -9,7 +9,7 @@ const cliRunWithWatch = ({
   extensions,
   force,
   indexFileExtension,
-  tsNodeNext
+  importExtension
 }: Options): void => {
   const { topDir } = runWithWatch({
     recursive,
@@ -17,7 +17,7 @@ const cliRunWithWatch = ({
     extensions,
     force,
     indexFileExtension,
-    tsNodeNext
+    importExtension
   })
 
   // TODO: Nicer looking logging

--- a/lib/createIndex/Options.ts
+++ b/lib/createIndex/Options.ts
@@ -6,7 +6,7 @@ interface Options {
   subDirsToInclude: Set<string>
   force: boolean
   indexFileExtension: string
-  tsNodeNext: boolean
+  importExtension?: string
 }
 
 export default Options

--- a/lib/createIndex/createIndex.ts
+++ b/lib/createIndex/createIndex.ts
@@ -9,7 +9,7 @@ const createIndex = async ({
   force,
   subDirsToInclude,
   indexFileExtension,
-  tsNodeNext
+  importExtension
 }: Options): Promise<boolean> => {
   const indexFileName = `index${indexFileExtension}`
   const path = join(dir, indexFileName)
@@ -39,11 +39,11 @@ const createIndex = async ({
   }
   const fileStr = [
     ...files.map(({ nameWithoutExtension, extension }) => {
-      const fileName = `${nameWithoutExtension}${tsNodeNext ? '.js' : extension}`
+      const fileName = `${nameWithoutExtension}${importExtension ?? extension}`
       return `export { default as ${nameWithoutExtension} } from './${fileName}'`
     }),
     ...[...subDirsToInclude].map(subDir =>
-      `export * as ${subDir} from './${subDir}/${indexFileName}'`)
+      `export * as ${subDir} from './${subDir}/index${importExtension ?? indexFileExtension}'`)
   ]
     .map(str => `${str}\n`)
     .join('')

--- a/lib/run/run.ts
+++ b/lib/run/run.ts
@@ -33,7 +33,7 @@ const run = (options: Options): ProcessDirResult => {
           .map(({ dir }) => basename(dir))),
         force: options.force,
         indexFileExtension: options.indexFileExtension,
-        tsNodeNext: options.tsNodeNext
+        importExtension: options.importExtension
       })
     })()
     return {

--- a/lib/runWithWatch/Options.ts
+++ b/lib/runWithWatch/Options.ts
@@ -3,7 +3,7 @@ interface Options {
   recursive: boolean
   force: boolean
   indexFileExtension: string
-  tsNodeNext: boolean
+  importExtension?: string
   extensions: string[]
 }
 

--- a/lib/runWithWatch/runWithWatch.ts
+++ b/lib/runWithWatch/runWithWatch.ts
@@ -15,7 +15,7 @@ const runWithWatch = ({
   recursive,
   force,
   indexFileExtension,
-  tsNodeNext,
+  importExtension,
   extensions
 }: Options): RunWithWatchReturn => {
   let ready = false
@@ -28,7 +28,7 @@ const runWithWatch = ({
           force,
           indexFileExtension,
           subDirsToInclude: subDirsWithIndexFiles,
-          tsNodeNext
+          importExtension
         }))
       }
       createIndexForDir()


### PR DESCRIPTION
Closes #7 

Added an option called `--importExtension` (`-i` for short). This customizes the imported extension. You can change it to `.js` to act like `--tsNodeNext` option. You can make it `""` to import without extension.

Removed `--tsNodeNext` option because you can just use `--importExtension .js`